### PR TITLE
WIP Use bash script to build docker images

### DIFF
--- a/.github/workflows/docker.publish.yml
+++ b/.github/workflows/docker.publish.yml
@@ -1,0 +1,77 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  schedule:
+    - cron: '0 5 * * *'
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [master, 4.11-latest, 4.10-latest, 4.9-latest, 4.8-latest, 4.7-latest, v4.11.1, v4.11.0, v4.10.2, v4.10.1, v4.10.0]
+        debug: [0, 1]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/wilfwilson/gap-docker-${{ matrix.branch }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image for minimal
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: ./gap/
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GAP_VERSION=${{ matrix.branch }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image for full
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: ./gap/
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GAP_VERSION=${{ matrix.branch }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,153 @@
+FROM ubuntu:21.10 AS base
+
+LABEL maintainer="The GAP Group <support@gap-system.org>"
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Prerequisites
+RUN    apt-get update -qq \
+    && apt-get -qq install -y \
+            autoconf \
+            autogen \
+            automake \
+            build-essential \
+            cmake \
+            curl \
+            g++ \
+            gcc \
+            git \
+            libgmp-dev \
+            libreadline6-dev \
+            libtool \
+            m4 \
+            sudo \
+            unzip \
+            wget
+
+# add gap user
+RUN    adduser --quiet --shell /bin/bash --gecos "GAP user,101,," --disabled-password gap \
+    && adduser gap sudo \
+    && chown -R gap:gap /home/gap/ \
+    && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
+    && cd /home/gap \
+    && touch .sudo_as_admin_successful
+
+ENV LD_LIBRARY_PATH /usr/local/lib:${LD_LIBRARY_PATH}
+
+# Set up new user and home directory in environment.
+USER gap
+ENV HOME /home/gap
+
+# Note that WORKDIR will not expand environment variables in docker versions < 1.3.1.
+# See docker issue 2637: https://github.com/docker/docker/issues/2637
+# Start at $HOME.
+WORKDIR /home/gap
+
+# Start from a BASH shell.
+CMD ["bash"]
+
+
+##########################################################################################
+# all-deps has all packages installed that are needed to compile all GAP packages
+FROM base AS all-deps
+
+LABEL maintainer="The GAP Group <support@gap-system.org>"
+
+ENV DEBIAN_FRONTEND noninteractive
+
+USER root
+ENV HOME /home/root
+
+# Prerequisites
+RUN    apt-get -qq install -y \
+        gcc-multilib \
+        libcdd-dev \
+        libcurl4-openssl-dev \
+        libflint-dev \
+        libglpk-dev \
+        libgmpxx4ldbl \
+        libmpc-dev \
+        libmpfi-dev \
+        libmpfr-dev \
+        libncurses5-dev \
+        libntl-dev \
+        libxml2-dev \
+        libzmq3-dev \
+        libx11-dev \
+        libxaw7-dev \
+        libxt-dev
+
+USER gap
+ENV HOME /home/gap
+
+
+##########################################################################################
+
+FROM base AS gap-minimal
+
+LABEL maintainer="The GAP Group <support@gap-system.org>"
+
+ARG GAP_VERSION
+
+ENV DEBIAN_FRONTEND noninteractive
+
+ADD ./prepare_gap.sh .
+RUN ./prepare_gap.sh -v ${GAP_VERSION} -d 0 -t minimal \
+    && rm prepare_gap.sh
+
+ENV GAP_HOME /home/gap/inst/gap-${GAP_VERSION}
+ENV PATH ${GAP_HOME}/bin:${PATH}
+
+
+##########################################################################################
+
+FROM all-deps AS gap-full
+
+LABEL maintainer="The GAP Group <support@gap-system.org>"
+
+ARG GAP_VERSION
+
+ENV DEBIAN_FRONTEND noninteractive
+
+ADD ./prepare_gap.sh .
+RUN ./prepare_gap.sh -v ${GAP_VERSION} -d 0 -t full \
+    && rm prepare_gap.sh
+
+ENV GAP_HOME /home/gap/inst/gap-${GAP_VERSION}
+ENV PATH ${GAP_HOME}/bin:${PATH}
+
+
+##########################################################################################
+
+FROM base AS gap-minimal-debug
+
+LABEL maintainer="The GAP Group <support@gap-system.org>"
+
+ARG GAP_VERSION
+
+ENV DEBIAN_FRONTEND noninteractive
+
+ADD ./prepare_gap.sh .
+RUN ./prepare_gap.sh -v ${GAP_VERSION} -d 1 -t minimal \
+    && rm prepare_gap.sh
+
+ENV GAP_HOME /home/gap/inst/gap-${GAP_VERSION}
+ENV PATH ${GAP_HOME}/bin:${PATH}
+
+
+##########################################################################################
+
+FROM all-deps AS gap-full-debug
+
+LABEL maintainer="The GAP Group <support@gap-system.org>"
+
+ARG GAP_VERSION
+
+ENV DEBIAN_FRONTEND noninteractive
+
+ADD ./prepare_gap.sh .
+RUN ./prepare_gap.sh -v ${GAP_VERSION} -d 1 -t full \
+    && rm prepare_gap.sh
+
+ENV GAP_HOME /home/gap/inst/gap-${GAP_VERSION}
+ENV PATH ${GAP_HOME}/bin:${PATH}

--- a/prepare_gap.sh
+++ b/prepare_gap.sh
@@ -1,0 +1,139 @@
+#! /bin/bash
+
+# -v options accepts: master, 4.7-latest, 4.8-latest, 4.9-latest, 4.10-latest
+# 4.11-latest, 4.11.1, 4.11.0. 4.10.2, 4.10.1, 4.10.0
+# -d accepts: 0 or 1
+# -t accepts: full or minimal
+
+
+# standard options
+VERSION=master
+DEBUG=0
+TYPE=minimal
+# this has to be changed manually upon new release wich isn't ideal!
+LATEST_VERSION=v4.11.1
+
+while getopts ":v:d:t:" options; do
+
+    case "${options}" in
+        v)
+            VERSION=${OPTARG}
+            ;;
+        d)
+            DEBUG=${OPTARG}
+            ;;
+        t)
+            TYPE=${OPTARG}
+            ;;
+        :)                                    
+            echo "Error: -${OPTARG} requires an argument."
+            exit                       
+            ;;
+        *)
+            echo "unsupported options"
+            exit
+            ;;
+    esac
+
+done
+
+if [[ "$TYPE" != "minimal" ]] && [[ "$TYPE" != "full" ]] ; then
+    echo "invalid argument for -t option"
+    exit
+fi
+
+declare -A KNOWN_BRANCHES=(
+    [master]=1 [stable-4.7]=1 [stable-4.8]=1 [stable-4.9]=1 [stable-4.10]=1 [stable-4.11]=1
+)
+
+declare -A KNOWN_RELEASES=(
+    [v4.11.1]=1 [v4.11.0]=1 [v4.10.2]=1 [v4.10.1]=1 [v4.10.0]=1
+)
+
+if [[ "${VERSION: -7}" = "-latest" ]] || [[ $VERSION = "master" ]] ; then
+    if [[ "${VERSION: -7}" = "-latest" ]] ; then
+        echo "is latest"
+        GAP_VERSION=stable-${VERSION/%-latest}
+        echo "$GAP_VERSION"
+    else 
+        GAP_VERSION=master
+    fi
+
+    # make sure the branch is known
+    if [[ -z "${KNOWN_BRANCHES[$GAP_VERSION]}" ]] ; then
+        echo "version indicates branch in the GAP repository which does not exist"
+        exit
+    fi
+
+    mkdir /home/gap/inst/ 
+    cd /home/gap/inst/ || exit 
+    git clone --depth=1 -b "${GAP_VERSION}" https://github.com/gap-system/gap gap-"${GAP_VERSION}" 
+    cd gap-"${GAP_VERSION}" || exit 
+
+else
+    echo "stable!"
+    GAP_VERSION=v${VERSION/%-latest}
+    echo "$GAP_VERSION"
+
+    # make sure the version is known
+    if [[ -z "${KNOWN_RELEASES[$GAP_VERSION]}" ]] ; then
+        echo "version indicates release which does not exist"
+        exit
+    fi
+
+    mkdir /home/gap/inst/ 
+    cd /home/gap/inst/ || exit 
+    wget https://github.com/gap-system/gap/releases/download/"${GAP_VERSION}"/gap-"${GAP_VERSION/#v}"-core.zip 
+    unzip gap-"${GAP_VERSION/#v}"-core.zip 
+    rm gap-"${GAP_VERSION/#v}"-core.zip 
+    cd gap-"${GAP_VERSION/#v}" || exit
+fi
+ 
+./autogen.sh 
+
+if [[ "$DEBUG" -eq 0 ]] ; then 
+    ./configure ; 
+else 
+    ./configure --enable-debug ; 
+fi
+
+make -j 12
+cp bin/gap.sh bin/gap
+
+case $TYPE in
+    minimal)
+        echo "minimal"
+        mkdir pkg 
+        cd pkg || exit  
+        if [[ "$GAP_VERSION" = "$LATEST_VERSION" ]] ; then
+            echo "latest_version"
+            URL_STRING="stable-${GAP_VERSION/#v}"
+            URL_STRING="${URL_STRING%.*}"
+            wget https://files.gap-system.org/gap4pkgs/packages-required-"${URL_STRING}".tar.gz
+            tar xzf packages-required-"${URL_STRING}".tar.gz 
+            rm packages-required-"${URL_STRING}".tar.gz
+        else 
+            wget https://files.gap-system.org/gap4pkgs/packages-required-"${GAP_VERSION}".tar.gz
+            tar xzf packages-required-"${GAP_VERSION}".tar.gz 
+            rm packages-required-"${GAP_VERSION}".tar.gz
+        fi
+        ;;
+    full)
+        echo "full"
+        mkdir pkg 
+        cd pkg || exit  
+        if [[ "$GAP_VERSION" = "$LATEST_VERSION" ]] ; then
+            echo "latest_version"
+            URL_STRING="stable-${GAP_VERSION/#v}"
+            URL_STRING="${URL_STRING%.*}"
+            wget https://files.gap-system.org/gap4pkgs/packages-required-"${URL_STRING}".tar.gz
+            tar xzf packages-required-"${URL_STRING}".tar.gz 
+            rm packages-required-"${URL_STRING}".tar.gz
+        else 
+            wget https://files.gap-system.org/gap4pkgs/packages-"${GAP_VERSION}".tar.gz
+            tar xzf packages-"${GAP_VERSION}".tar.gz 
+            rm packages-"${GAP_VERSION}".tar.gz
+        fi
+        ../bin/BuildPackages.sh --parallel
+        ;;
+esac


### PR DESCRIPTION
I've read the discussion around PR #3 and tried to incorporate all suggestions to come as close as possible to @fingolfin vision as described in Issue #1. 

The `prepare_gap.sh` script does the downloading/cloning, compiling and downloading and compiling of the packages. It has three options `-v`, `-t` and `-d`. The first is to specify a version of GAP, the second to decide whether to download only required packages (argument: `minimal`) or all packages (argument: `full`) and the last is to choose whether to build GAP in debug mode or not (argument: `0` or `1`).  

The Dockerfile defines several build targets. `base` is the newest ubuntu with only packages installed that are necessary to download and compile GAP. `all-deps` then adds packages required to build all packages. 
Then there are targets of the form "gap-{minimal,full}(-debug)" that then use the script `prepare_gap.sh` to build GAP accordingly. Note that we could also use another build argument to decide whether to build a debug version or not. But we cannot easily use a build argument to decide between minimal and full as these are based on different images (namely `base` or `all-deps`) and Dockerfiles are just not flexible enough to do that (afaik).

This PR does not implement correct github actions yet. And there's the question on how to name the various docker images in a consistent way. The dockerfile and script mainly work on my local machine atm some things likely have to be changed to make it work with ghcr.io.

Before I continue with this I'd love to hear feedback and suggestions!